### PR TITLE
Evaluate examples on ctrl-enter

### DIFF
--- a/src/cljs_live/examples.cljs
+++ b/src/cljs_live/examples.cljs
@@ -39,7 +39,7 @@
 
 ")
                    [:.f2.mt4.mb2.tc "examples"]
-                   [:p.tc.mb3 "(hit command-enter in a textarea to re-evaluate)"]
+                   [:p.tc.mb3 "(hit ctrl-enter in a textarea to re-evaluate)"]
                    (for [{:keys [render]} @examples]
                      (render))]))
 
@@ -59,7 +59,7 @@
 
                                        [:textarea.fl.w-50.pre-wrap.h4
                                         {:on-change   #(reset! source (.-value (.-currentTarget %)))
-                                         :on-key-down #(when (and (= 13 (.-which %)) (.-metaKey %))
+                                         :on-key-down #(when (and (= 13 (.-which %)) (.-ctrlKey %))
                                                          (eval))
                                          :value       @source}]
                                        [:.fl.w-50.pl4


### PR DESCRIPTION
Making the examples friendly to non-Mac non-Chrome users (:

I propose changing the evaluate keybinding to [ctrl](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/ctrlKey)-enter rather than cmd-enter because the `KeyboardEvent.metaKey` is not available on Firefox 48+ for non-Mac users:

> Note: On Macintosh keyboards, this is the ⌘ Command key. On Windows keyboards, this is the Windows key (⊞ Windows).
> 
> At least as of Firefox 48, the ⊞ Windows key is not considered the "Meta" key. KeyboardEvent.metaKey is false when the ⊞ Windows is pressed.

([source](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey))